### PR TITLE
Add logging for which git result

### DIFF
--- a/bun-sidecar/src/server-routes/git-sync.ts
+++ b/bun-sidecar/src/server-routes/git-sync.ts
@@ -110,6 +110,7 @@ export const gitInstalledRoute: RouteHandler<GitInstalledResponse> = {
 
             // Use 'which git' to check if git is in PATH (PATH is augmented at module load)
             const whichResult = await $`which git 2>&1`.nothrow();
+            logger.info("which git result", { exitCode: whichResult.exitCode, output: whichResult.text().trim() });
 
             if (whichResult.exitCode !== 0) {
                 logger.info("Git not found in PATH");


### PR DESCRIPTION
Adds logging to capture the exit code and output of the `which git` command in the gitInstalledRoute handler.

This helps diagnose git detection issues by showing exactly what the command returns.

Fixes #13

---

Generated with [Claude Code](https://claude.ai/code)