### PR TITLE
Fix: Unable to delete existing chat conversations

### DIFF
--- a/bun-sidecar/src/components/ui/alert-dialog.tsx
+++ b/bun-sidecar/src/components/ui/alert-dialog.tsx
@@ -36,9 +36,10 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50",
         className
       )}
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
       {...props}
     />
   )
@@ -54,9 +55,10 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
+        style={{ backgroundColor: "#ffffff", opacity: 1 }}
         {...props}
       />
     </AlertDialogPortal>

--- a/bun-sidecar/src/server-routes/chat-routes.ts
+++ b/bun-sidecar/src/server-routes/chat-routes.ts
@@ -960,46 +960,6 @@ export const chatRoutes = {
         },
     },
 
-    "/api/chat/sessions/history/*": {
-        async GET(req: Request) {
-            try {
-                const url = new URL(req.url);
-                const pathParts = url.pathname.split("/");
-                // Session ID is at the end: /api/chat/sessions/history/{sessionId}
-                const sessionId = pathParts[pathParts.length - 1];
-                const claudeDir = getClaudeSessionsDir();
-                const sessionFile = join(claudeDir, `${sessionId}.jsonl`);
-
-                chatLogger.info("Loading session history", {
-                    sessionId,
-                    claudeDir,
-                    sessionFile,
-                    dirExists: existsSync(claudeDir),
-                    fileExists: existsSync(sessionFile)
-                });
-
-                if (!existsSync(sessionFile)) {
-                    chatLogger.warn("Session file not found", { sessionFile });
-                    return Response.json(
-                        { error: "Session not found", sessionFile },
-                        { status: 404 }
-                    );
-                }
-
-                const messages = await readJSONL<SDKMessage>(sessionFile);
-                console.log(`[API] Loaded ${messages.length} messages for session ${sessionId}`);
-
-                return Response.json({ messages });
-            } catch (error) {
-                console.error("[API] Error loading session history:", error);
-                return Response.json(
-                    { error: "Failed to load session history" },
-                    { status: 500 }
-                );
-            }
-        },
-    },
-
     "/api/chat/sessions/update": {
         async PUT(req: Request) {
             try {
@@ -1162,6 +1122,47 @@ export const chatRoutes = {
                 console.error("[API] Error searching sessions:", error);
                 return Response.json(
                     { error: "Failed to search sessions" },
+                    { status: 500 }
+                );
+            }
+        },
+    },
+
+    // Wildcard route MUST be last to avoid matching specific routes like /delete, /update, /search
+    "/api/chat/sessions/history/*": {
+        async GET(req: Request) {
+            try {
+                const url = new URL(req.url);
+                const pathParts = url.pathname.split("/");
+                // Session ID is at the end: /api/chat/sessions/history/{sessionId}
+                const sessionId = pathParts[pathParts.length - 1];
+                const claudeDir = getClaudeSessionsDir();
+                const sessionFile = join(claudeDir, `${sessionId}.jsonl`);
+
+                chatLogger.info("Loading session history", {
+                    sessionId,
+                    claudeDir,
+                    sessionFile,
+                    dirExists: existsSync(claudeDir),
+                    fileExists: existsSync(sessionFile)
+                });
+
+                if (!existsSync(sessionFile)) {
+                    chatLogger.warn("Session file not found", { sessionFile });
+                    return Response.json(
+                        { error: "Session not found", sessionFile },
+                        { status: 404 }
+                    );
+                }
+
+                const messages = await readJSONL<SDKMessage>(sessionFile);
+                console.log(`[API] Loaded ${messages.length} messages for session ${sessionId}`);
+
+                return Response.json({ messages });
+            } catch (error) {
+                console.error("[API] Error loading session history:", error);
+                return Response.json(
+                    { error: "Failed to load session history" },
                     { status: 500 }
                 );
             }


### PR DESCRIPTION
### Description
This PR fixes a bug where users were unable to delete existing chat conversations. Previously, when attempting to remove a chat from the history, the action failed and the conversation remained visible in the list.

### Rationale
Users need to be able to manage their chat history and remove old or unwanted conversations. This fix ensures the delete action updates the UI state correctly and removes the data.

### Related Issue
Fixes #34