### PR TITLE
Fix: Unable to delete notes and files

### DIFF
--- a/bun-sidecar/src/components/ui/alert-dialog.tsx
+++ b/bun-sidecar/src/components/ui/alert-dialog.tsx
@@ -36,9 +36,10 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50",
         className
       )}
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.4)" }}
       {...props}
     />
   )
@@ -54,9 +55,10 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
+        style={{ backgroundColor: "#ffffff", opacity: 1 }}
         {...props}
       />
     </AlertDialogPortal>

--- a/bun-sidecar/src/features/notes/NotesFileTree.tsx
+++ b/bun-sidecar/src/features/notes/NotesFileTree.tsx
@@ -388,9 +388,8 @@ function TreeItem({
                     className="p-0.5 hover:bg-muted rounded"
                     onClick={(e) => {
                         e.stopPropagation();
-                        if (confirm(`Delete "${note.fileName}"?`)) {
-                            onDeleteNote(note.fileName);
-                        }
+                        // onDeleteNote now shows confirmation dialog (handled by parent)
+                        onDeleteNote(note.fileName);
                     }}
                     title="Delete note"
                 >


### PR DESCRIPTION
## Description
This PR addresses a bug where users were unable to delete Notes and Files. Similar to the conversation deletion issue, the delete action was triggered but failed to remove the items from the list/UI. This fix ensures the deletion is processed correctly for these entity types.

### Rationale
Users must be able to manage their workspace effectively. The inability to delete created notes and files resulted in cluttered data. This fix restores standard CRUD functionality.