### PR TITLE
docs: add Application Design Principles to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,12 @@ import { KeyboardIndicator } from "@/components/KeyboardIndicator";
 <Button><KeyboardIndicator keys={['cmd', 'n']} /> New</Button>
 ```
 
+### Application Design Principles
+- Reuse previously defined components over creating net new code. Especially when reusing dialogs and similar.
+- Try to hide buttons to keep visual complexity down. Reveal on hover is a good technique.
+- Always use `useTheme` for styling
+- Add commands for functionality over discrete buttons
+
 ## Critical Implementation Rules
 
 ### Type Safety


### PR DESCRIPTION
Adds a new "Application Design Principles" section to CLAUDE.md with four core design principles:

- Reuse previously defined components over creating new code
- Hide buttons to reduce visual complexity (reveal on hover)
- Always use useTheme for styling
- Prefer commands over discrete buttons

Closes #42

---

Generated with [Claude Code](https://claude.ai/code)