### PR TITLE
Remove aggressive GitHub sync setup popup

### DIFF
--- a/bun-sidecar/src/App.tsx
+++ b/bun-sidecar/src/App.tsx
@@ -19,7 +19,6 @@ import { Toaster } from "@/components/ui/sonner";
 import { WorkspaceProvider } from "./contexts/WorkspaceContext";
 import { KeyboardShortcutsProvider } from "./contexts/KeyboardShortcutsContext";
 import { GHSyncProvider } from "./contexts/GHSyncContext";
-import { GHSyncSetupPrompt } from "./components/GHSyncSetupPrompt";
 import { CommandDialogProvider } from "./components/CommandDialogProvider";
 import { CommandMenu } from "./components/CommandMenu";
 import { NotesCommandMenu } from "./components/NotesCommandMenu";
@@ -126,7 +125,6 @@ export function App() {
                                             <CommandMenu />
                                             <NotesCommandMenu />
                                             <TabSwitcherMenu />
-                                            <GHSyncSetupPrompt />
                                         </CommandDialogProvider>
                                     </GHSyncProvider>
                                 </KeyboardShortcutsProvider>


### PR DESCRIPTION
Fixes #77

## Changes
- Removed GHSyncSetupPrompt component from App.tsx
- Users will now only see sync setup notice on the /sync page
- The sync page already has a comprehensive "Setup Required" card

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/firstloophq/nomendex/actions/runs/21271289991