### PR TITLE
fix: change HTML title from 'MCP Client' to 'Nomendex'

### DIFF
--- a/bun-sidecar/src/index.html
+++ b/bun-sidecar/src/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MCP Client</title>
+        <title>Nomendex</title>
         <link rel="stylesheet" href="./output.css" />
         <script type="module" src="./frontend.tsx" async></script>
     </head>


### PR DESCRIPTION
Fixes #60

Updated the HTML page title from "MCP Client" to "Nomendex" in `bun-sidecar/src/index.html`.

Generated with [Claude Code](https://claude.ai/code)