### PR TITLE
feat: Add scroll position persistence for chat tabs

### DIFF
--- a/bun-sidecar/src/components/ai-elements/conversation.tsx
+++ b/bun-sidecar/src/components/ai-elements/conversation.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import type { ComponentProps } from "react";
+import { forwardRef, type ComponentProps } from "react";
 
 export type ConversationProps = ComponentProps<"div">;
 
-export const Conversation = ({ className, ...props }: ConversationProps) => (
-  <div
-    className={cn("relative flex-1 overflow-y-auto", className)}
-    role="log"
-    {...props}
-  />
+export const Conversation = forwardRef<HTMLDivElement, ConversationProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("relative flex-1 overflow-y-auto", className)}
+      role="log"
+      {...props}
+    />
+  )
 );
+Conversation.displayName = "Conversation";
 
 export type ConversationContentProps = ComponentProps<"div">;
 

--- a/mac-app/macos-host/Info.plist
+++ b/mac-app/macos-host/Info.plist
@@ -15,9 +15,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.0-alpha.27</string>
+  <string>0.2.0-alpha.28</string>
   <key>CFBundleVersion</key>
-  <string>27</string>
+  <string>28</string>
   <key>LSMinimumSystemVersion</key>
   <string>12.0</string>
   <key>NSPrincipalClass</key>


### PR DESCRIPTION
## Summary

Adds scroll position persistence for chat tabs, matching the existing behavior for notes tabs.

## Changes

- Import and use `useTabScrollPersistence` hook in chat-view.tsx
- Replace `conversationRef` with `scrollRef` from the hook
- Scroll position now persists when switching between chat tabs

Fixes #86

---

Generated with [Claude Code](https://claude.ai/code)