### PR TITLE
fix: MacOS CMD+Enter checkbox toggle in ProseMirror

### DIFF
--- a/bun-sidecar/src/features/notes/note-view.tsx
+++ b/bun-sidecar/src/features/notes/note-view.tsx
@@ -8,7 +8,8 @@ import { exampleSetup } from "prosemirror-example-setup";
 import { sinkListItem, liftListItem, wrapInList } from "prosemirror-schema-list";
 import { keymap } from "prosemirror-keymap";
 import { chainCommands } from "prosemirror-commands";
-import { todoKeymap, todoPlugin } from "./simple-todo";
+import { todoKeymap, todoPlugin, toggleTodoAtLine } from "./simple-todo";
+import { registerProseMirrorCmdEnter } from "@/hooks/useNativeKeyboardBridge";
 import {
     tableSchema,
     tableMarkdownParser,
@@ -628,12 +629,29 @@ export function NotesView(props: NotesViewProps) {
             viewRef.current.updateState(stateWithNewDoc);
             currentNoteFileNameRef.current = noteFileName;
             initializedContentRef.current = contentToUse;
-            return;
+
+            // Re-register Cmd+Enter handler (cleanup from previous render unregistered it)
+            const view = viewRef.current;
+            const unregisterCmdEnter = registerProseMirrorCmdEnter(view.dom as HTMLElement, () => {
+                return toggleTodoAtLine(view.state, view.dispatch);
+            });
+
+            return () => {
+                unregisterCmdEnter();
+            };
         }
 
         // If no note change and editor exists, nothing to do
         if (!isNewNote && viewRef.current) {
-            return;
+            // Re-register Cmd+Enter handler (cleanup from previous render unregistered it)
+            const view = viewRef.current;
+            const unregisterCmdEnter = registerProseMirrorCmdEnter(view.dom as HTMLElement, () => {
+                return toggleTodoAtLine(view.state, view.dispatch);
+            });
+
+            return () => {
+                unregisterCmdEnter();
+            };
         }
 
         // Only destroy if we're creating fresh (shouldn't happen often now)
@@ -842,6 +860,11 @@ export function NotesView(props: NotesViewProps) {
         initializedContentRef.current = contentToUse;
         currentNoteFileNameRef.current = noteFileName;
 
+        // Register Cmd+Enter handler for todo toggle in native Mac app
+        const unregisterCmdEnter = registerProseMirrorCmdEnter(view.dom as HTMLElement, () => {
+            return toggleTodoAtLine(view.state, view.dispatch);
+        });
+
         // Helper to scroll to a specific line number with context above
         const scrollToLineNumber = (lineNum: number) => {
             const doc = view.state.doc;
@@ -913,6 +936,7 @@ export function NotesView(props: NotesViewProps) {
         const toolbarContainer = toolbarContainerRef.current;
 
         return () => {
+            unregisterCmdEnter();
             if (viewRef.current) {
                 viewRef.current.destroy();
                 viewRef.current = null;

--- a/mac-app/macos-host/Info.plist
+++ b/mac-app/macos-host/Info.plist
@@ -15,9 +15,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.0-alpha.34</string>
+  <string>0.2.0-alpha.35</string>
   <key>CFBundleVersion</key>
-  <string>34</string>
+  <string>35</string>
   <key>LSMinimumSystemVersion</key>
   <string>12.0</string>
   <key>NSPrincipalClass</key>


### PR DESCRIPTION
Previously, CMD+Enter only worked for dialogs via CustomEvent.
Now detects ProseMirror editor focus and dispatches synthetic
KeyboardEvent to trigger the checkbox toggle keymap handler.

Fixes #73

Generated with [Claude Code](https://claude.ai/code)