### PR TITLE
Fix: Tag Creation API 500 Error and Improved Error Propagation

### DIFF
--- a/bun-sidecar/src/hooks/useNotesAPI.ts
+++ b/bun-sidecar/src/hooks/useNotesAPI.ts
@@ -9,7 +9,16 @@ async function fetchAPI<T>(endpoint: string, body: Record<string, unknown> = {})
         body: JSON.stringify(body),
     });
     if (!response.ok) {
-        throw new Error(`API error: ${response.status}`);
+        let errorMessage = `API error: ${response.status}`;
+        try {
+            const errorData = await response.json();
+            if (errorData && typeof errorData.error === 'string') {
+                errorMessage = errorData.error;
+            }
+        } catch {
+            // parsing failed, use default message
+        }
+        throw new Error(errorMessage);
     }
     return response.json();
 }

--- a/bun-sidecar/src/server-routes/notes-routes.ts
+++ b/bun-sidecar/src/server-routes/notes-routes.ts
@@ -199,9 +199,16 @@ export const notesRoutes = {
     },
     "/api/notes/tags/create-explicit": {
         async POST(req: Request) {
-            const args = (await req.json()) as { tagName: string };
-            const result = await createExplicitTag({ tagName: args.tagName });
-            return Response.json(result);
+            try {
+                const args = (await req.json()) as { tagName: string };
+                const result = await createExplicitTag({ tagName: args.tagName });
+                return Response.json(result);
+            } catch (error) {
+                // Return 400 for validation errors (which createExplicitTag throws), 500 for others
+                const message = error instanceof Error ? error.message : "Unknown error";
+                const status = message.includes("Invalid tag name") ? 400 : 500;
+                return Response.json({ error: message }, { status });
+            }
         },
     },
     "/api/notes/tags/delete-explicit": {

--- a/bun-sidecar/src/server.ts
+++ b/bun-sidecar/src/server.ts
@@ -13,6 +13,7 @@ import { chatRoutes } from "./server-routes/chat-routes";
 import { agentsRoutes } from "./server-routes/agents-routes";
 import { secretsRoutes } from "./server-routes/secrets-routes";
 import { skillsRoutes } from "./server-routes/skills-routes";
+import { projectsRoutes } from "./server-routes/projects-routes";
 import { workspacesRoutes } from "./server-routes/workspaces-routes";
 import { mcpServersRoutes } from "./server-routes/mcp-servers-routes";
 import { filesystemRoutes } from "./server-routes/filesystem-routes";
@@ -20,7 +21,6 @@ import { uploadsRoutes } from "./server-routes/uploads-routes";
 import { versionRoutes } from "./server-routes/version-routes";
 import { logsRoutes } from "./server-routes/logs-routes";
 import { dictionariesRoutes } from "./server-routes/dictionaries-routes";
-import { projectsRoutes } from "./server-routes/projects-routes";
 
 // Terminal WebSocket data type
 interface TerminalWSData {


### PR DESCRIPTION
Fixes #126 

## Description

This PR addresses an issue where creating a tag with invalid characters (e.g., spaces or special symbols) caused a **500 Internal Server Error**. It also improves how the frontend handles and displays these validation errors to the user.

---

## Key Changes

### Server-side (`notes-routes.ts`)

* **Try-Catch Implementation:** Wrapped `createExplicitTag` in a block to handle validation errors gracefully.
* **Status Code Update:** Now returns a **400 Bad Request** for invalid tag names with a specific error message, instead of a generic 500 error.

### Frontend (`useNotesAPI.ts`)

* **Enhanced `fetchAPI`:** Updated the utility to parse and propagate error messages from the response body (specifically the `error` field).
* **User Feedback:** Ensures the UI displays helpful messages like *"Invalid tag name..."* instead of generic *"API error: 400"*.

### Cleanup (`server.ts`)

* Removed a duplicate import of `projectsRoutes`.

---

## Rationale / Tradeoffs

* **Rationale:** The previous behavior led to a poor user experience and potential server instability when invalid data was submitted. By catching these expected validation errors at the API boundary, we provide better feedback and more robust error handling.
* **Tradeoffs:** The error parsing in the frontend hook adds a small amount of overhead to failed requests, but the benefit of actionable error messages for the user far outweighs this cost.

---

## Breaking Changes

* **None.** This change preserves existing functionality while improving error reporting.