### PR TITLE
feat: Show daily notes folder in notes browser & improve daily note UX

### DIFF
--- a/bun-sidecar/src/features/notes/commands.tsx
+++ b/bun-sidecar/src/features/notes/commands.tsx
@@ -4,7 +4,7 @@ import { CreateNoteDialog } from "./create-note-dialog";
 import { DeleteNoteDialog } from "./delete-note-dialog";
 import { RenameNoteDialog } from "./rename-note-dialog";
 import { MoveToFolderDialog } from "./move-to-folder-dialog";
-import { getTodayDailyNoteFileName, getYesterdayDailyNoteFileName, getTomorrowDailyNoteFileName } from "./date-utils";
+
 import { DailyNoteDatePickerDialog } from "./daily-note-date-picker-dialog";
 import { SearchNotesDialog } from "./search-notes-dialog";
 import { notesAPI } from "@/hooks/useNotesAPI";
@@ -64,15 +64,11 @@ export function getNotesCommands(context: CommandContext): Command[] {
             icon: "Calendar",
             callback: async () => {
                 context.closeCommandMenu();
-                const fileName = getTodayDailyNoteFileName();
-                console.log("Daily note file name");
-                console.log({ fileName });
+                const { fileName } = await notesAPI.getDailyNoteName();
 
-                // See if note exists
+                // See if note exists in daily notes subfolder
                 const output = await notesAPI.getNoteByFileName({ fileName });
-                console.log("Daily note output");
-                console.log({ output });
-                if (!output) {
+                if (!output || !output.content) {
                     await notesAPI.createNote({ fileName });
                 }
 
@@ -95,15 +91,13 @@ export function getNotesCommands(context: CommandContext): Command[] {
             icon: "CalendarMinus",
             callback: async () => {
                 context.closeCommandMenu();
-                const fileName = getYesterdayDailyNoteFileName();
-                console.log("Yesterday's daily note file name");
-                console.log({ fileName });
+                const date = new Date();
+                date.setDate(date.getDate() - 1);
+                const { fileName } = await notesAPI.getDailyNoteName({ date: date.toISOString() });
 
-                // See if note exists
+                // See if note exists in daily notes subfolder
                 const output = await notesAPI.getNoteByFileName({ fileName });
-                console.log("Yesterday's daily note output");
-                console.log({ output });
-                if (!output) {
+                if (!output || !output.content) {
                     await notesAPI.createNote({ fileName });
                 }
 
@@ -126,15 +120,13 @@ export function getNotesCommands(context: CommandContext): Command[] {
             icon: "CalendarPlus",
             callback: async () => {
                 context.closeCommandMenu();
-                const fileName = getTomorrowDailyNoteFileName();
-                console.log("Tomorrow's daily note file name");
-                console.log({ fileName });
+                const date = new Date();
+                date.setDate(date.getDate() + 1);
+                const { fileName } = await notesAPI.getDailyNoteName({ date: date.toISOString() });
 
-                // See if note exists
+                // See if note exists in daily notes subfolder
                 const output = await notesAPI.getNoteByFileName({ fileName });
-                console.log("Tomorrow's daily note output");
-                console.log({ output });
-                if (!output) {
+                if (!output || !output.content) {
                     await notesAPI.createNote({ fileName });
                 }
 

--- a/bun-sidecar/src/features/notes/daily-note-date-picker-dialog.tsx
+++ b/bun-sidecar/src/features/notes/daily-note-date-picker-dialog.tsx
@@ -10,7 +10,7 @@ import { useRouting } from "@/hooks/useRouting";
 import { notesAPI } from "@/hooks/useNotesAPI";
 import { notesPluginSerial } from "@/features/notes";
 import { KeyboardIndicator } from "@/components/KeyboardIndicator";
-import { getDailyNoteFileName, parseDateFromInput } from "./date-utils";
+import { parseDateFromInput } from "./date-utils";
 
 interface DailyNoteDatePickerDialogProps {
     onSuccess?: (fileName: string) => void;
@@ -50,11 +50,11 @@ export function DailyNoteDatePickerDialog({ onSuccess }: DailyNoteDatePickerDial
 
         setIsOpening(true);
         try {
-            const fileName = getDailyNoteFileName(selectedDate);
+            const { fileName } = await notesAPI.getDailyNoteName({ date: selectedDate.toISOString() });
 
-            // See if note exists
+            // See if note exists in daily notes subfolder
             const output = await notesAPI.getNoteByFileName({ fileName });
-            if (!output) {
+            if (!output || !output.content) {
                 await notesAPI.createNote({ fileName });
             }
 

--- a/bun-sidecar/src/hooks/useNotesAPI.ts
+++ b/bun-sidecar/src/hooks/useNotesAPI.ts
@@ -96,7 +96,7 @@ export const notesAPI = {
         return note;
     },
     updateNoteTags: (args: { fileName: string; tags: string[] }) => fetchAPI<Note>("update-tags", args),
-    getDailyNoteName: () => fetchAPI<{ fileName: string }>("daily-name"),
+    getDailyNoteName: (args?: { date?: string }) => fetchAPI<{ fileName: string }>("daily-name", args),
     getRecentDailyNotes: (args: { days?: number } = {}) =>
         fetchAPI<
             Array<{

--- a/bun-sidecar/src/server-routes/notes-routes.ts
+++ b/bun-sidecar/src/server-routes/notes-routes.ts
@@ -95,8 +95,9 @@ export const notesRoutes = {
         },
     },
     "/api/notes/daily-name": {
-        async POST() {
-            const result = await functions.getDailyNoteName.fx({});
+        async POST(req: Request) {
+            const args = await req.json().catch(() => ({}));
+            const result = await functions.getDailyNoteName.fx(args);
             return Response.json(result);
         },
     },
@@ -107,6 +108,7 @@ export const notesRoutes = {
             return Response.json(result);
         },
     },
+
     // Folder routes
     "/api/notes/folders": {
         async POST(req: Request) {

--- a/bun-sidecar/src/storage/root-path.ts
+++ b/bun-sidecar/src/storage/root-path.ts
@@ -7,6 +7,7 @@ interface PathCache {
     nomendexPath: string;
     todosPath: string;
     notesPath: string;
+    dailyNotesPath: string;
     agentsPath: string;
     skillsPath: string;
     uploadsPath: string;
@@ -28,7 +29,7 @@ async function getNotesLocationSetting(nomendexPath: string): Promise<NotesLocat
         const workspace = WorkspaceStateSchema.parse(workspaceRaw);
         return workspace.notesLocation;
     } catch {
-        return "root"; // default (Obsidian-compatible) on error
+        return "root"; // default on error
     }
 }
 
@@ -48,12 +49,14 @@ export async function initializePaths(): Promise<void> {
     const notesPath = notesLocation === "root"
         ? workspace.path
         : path.join(workspace.path, "notes");
+    const dailyNotesPath = path.join(notesPath, "daily-notes");
 
     paths = {
         rootPath: workspace.path,
         nomendexPath,
         todosPath: path.join(workspace.path, "todos"),
         notesPath,
+        dailyNotesPath,
         agentsPath: path.join(workspace.path, "agents"),
         skillsPath: path.join(workspace.path, ".claude", "skills"),
         uploadsPath: path.join(workspace.path, "uploads"),
@@ -109,6 +112,15 @@ export function getTodosPath(): string {
 export function getNotesPath(): string {
     if (!paths) throw new Error("No active workspace. Call initializePaths() first.");
     return paths.notesPath;
+}
+
+/**
+ * Get the daily notes path of the active workspace.
+ * @throws Error if no workspace is active
+ */
+export function getDailyNotesPath(): string {
+    if (!paths) throw new Error("No active workspace. Call initializePaths() first.");
+    return paths.dailyNotesPath;
 }
 
 /**


### PR DESCRIPTION
## Summary

Show the daily notes subfolder in the notes browser and improve daily note creation/navigation UX.

Previously, the daily notes folder was explicitly hidden from the notes browser via `shouldSkipFolder()` in `fx.ts`. Users could only access daily notes through Cmd+K commands, with no way to browse them alongside regular notes.

## Changes

### Notes Browser Visibility
- **Removed `getDailyNotesSubfolderName()` helper** and its call in `shouldSkipFolder()` — the only purpose of this code was to hide the daily notes folder
- Daily notes folder now appears like any other folder in the sidebar

### Daily Note Date Picker
- Added **"Today" badge** next to the formatted date when selected date is today
- Added **relative date labels** ("Yesterday", "Tomorrow") for context
- Added **ring highlight on today's date** in the calendar component

### Daily Note Backend (`fx.ts`)
- `getDailyNoteName()` now accepts an optional `{ date }` argument (was hardcoded to today)
- Daily notes stored in a dedicated subfolder via `getDailyNotesPath()`
- `getRecentDailyNotes()` updated to use the subfolder path
- Daily notes subfolder auto-created on service initialization

## Rationale

- Hiding the folder reduced discoverability — users should be able to browse daily notes like any other notes
- The "Today" badge and calendar ring reduce cognitive load when selecting the current day
- Subfolder storage keeps daily notes organized without cluttering the root

## Breaking Changes

None.