### PR TITLE
Add mush workflow + Claude Code integration

### DIFF
--- a/.github/workflows/mush.yml
+++ b/.github/workflows/mush.yml
@@ -1,0 +1,34 @@
+name: Mush
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [closed]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  mush:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@mush')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@mush')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@mush')) ||
+      (github.event_name == 'issues') ||
+      (github.event_name == 'pull_request')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      checks: write
+      id-token: write
+      actions: read
+    uses: firstloophq/mush/.github/workflows/mush.yml@main
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      mush_app_id: ${{ secrets.MUSH_APP_ID }}
+      mush_app_private_key: ${{ secrets.MUSH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## 🐕 Mush — Claude Code Integration

This PR adds the GitHub Actions workflow for mush, a CLI/TUI for managing issues and handing off work to Claude Code.

### What's included

`.github/workflows/mush.yml` — triggers Claude Code on `@mush` mentions in issues and PRs, with automatic status label management via reusable composite actions.

### Setup required

1. Add `CLAUDE_CODE_OAUTH_TOKEN` as a repository secret
   (Settings → Secrets and variables → Actions → New repository secret)
2. Add `MUSH_APP_ID` and `MUSH_APP_PRIVATE_KEY` as organization secrets
   (these should already exist as org-level secrets)
3. Merge this PR

### Labels created

The following labels were already added to this repo:
`mush/type:*`, `mush/priority:*`, `mush/{stage}:{check}:{status}`

### Composite Actions

The workflow uses composite actions hosted in a public mush repository. These actions handle:
- Issue number resolution from `mush:meta` tags
- Atomic label swapping (one label per prefix group)
- Error handling and status updates

Updating the composite actions in the mush repo propagates to all tracked repos automatically.
