### PR TITLE
Remove leftover tldraw CSS import that broke release build

### DIFF
--- a/bun-sidecar/src/input.css
+++ b/bun-sidecar/src/input.css
@@ -1,7 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
-@import url('tldraw/tldraw.css');
 @import "tailwindcss";
-/* TLDraw Agent Styles */
 
 @custom-variant dark (&:is(.dark *));
 
@@ -1170,17 +1168,6 @@ button.prompt-tag span {
 
 .prompt-tag svg {
 	flex-shrink: 0;
-}
-
-/* Diff viewer */
-
-.tldraw-viewer {
-	height: 100px;
-	position: relative;
-}
-
-.tldraw-viewer .tlui-tooltip {
-	display: none;
 }
 
 .diff-shape-create-shadow {

--- a/bun-sidecar/src/output.css
+++ b/bun-sidecar/src/output.css
@@ -1,6 +1,5 @@
 /*! tailwindcss v4.1.18 | MIT License | https://tailwindcss.com */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
-@import url('tldraw/tldraw.css');
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
@@ -4649,13 +4648,6 @@ button.prompt-tag span {
 }
 .prompt-tag svg {
   flex-shrink: 0;
-}
-.tldraw-viewer {
-  height: 100px;
-  position: relative;
-}
-.tldraw-viewer .tlui-tooltip {
-  display: none;
 }
 .diff-shape-create-shadow {
   filter: drop-shadow(	calc(var(--tl-scale) * 1px) calc(var(--tl-scale) * 1px) 0px rgba(0, 200, 0, 50%)	)	drop-shadow(calc(var(--tl-scale) * -1px) calc(var(--tl-scale) * -1px) 0px rgba(0, 200, 0, 50%))	drop-shadow(calc(var(--tl-scale) * 1px) calc(var(--tl-scale) * -1px) 0px rgba(0, 200, 0, 50%))	drop-shadow(calc(var(--tl-scale) * -1px) calc(var(--tl-scale) * 1px) 0px rgba(0, 200, 0, 50%));


### PR DESCRIPTION
The release workflow failed compiling the sidecar binary: `input.css` still imported `tldraw/tldraw.css` after tldraw was removed from dependencies in #180. The regular `bun run build` validation doesn't run the binary compile step, so CI on that PR stayed green.

Removes the import and the dead `.tldraw-viewer` styles; `output.css` regenerated. Verified locally with the exact `bun build --compile` command from `build_sidecar.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)